### PR TITLE
[add] pagination のための機能実装: question/index.ex にlimitとskipのクエリを指定可能にした。

### DIFF
--- a/web/controller/comment/create.ex
+++ b/web/controller/comment/create.ex
@@ -32,7 +32,7 @@ defmodule StackoverflowCloneL.Controller.Comment.Create do
 
           # 1. Requestの構築
           data_comment = %{
-            "id" => RandomString.stream(:alphanumeric) |> Enum.take(20) |> List.to_string,
+            "id" => RandomString.take(20, :alphanumeric),
             "user_id" => conn.assigns.me["_id"],
             "body" => conn.request.body["body"],
             "created_at" =>  Antikythera.Time.to_iso_timestamp(Antikythera.Time.now()),

--- a/web/controller/question/index.ex
+++ b/web/controller/question/index.ex
@@ -3,6 +3,8 @@ use Croma
 defmodule StackoverflowCloneL.Controller.Question.IndexRequestParams do
   use Croma.Struct, fields: [
     user_id:  Croma.TypeGen.nilable(Croma.String),
+    limit: Croma.TypeGen.nilable(Croma.NonNegInteger),
+    skip: Croma.TypeGen.nilable(Croma.NonNegInteger),
   ]
 end
 
@@ -13,11 +15,22 @@ defmodule StackoverflowCloneL.Controller.Question.Index do
   alias StackoverflowCloneL.Controller.Question.{Helper, IndexRequestParams}
 
   def index(conn) do
-    #IO.inspect conn
-    case IndexRequestParams.new(conn.request.query_params) do
-      {:error, _}      ->
+    #IO.inspect conn.request.query_params, label: "start"
+    queries = conn.request.query_params
+    queries = Enum.map( queries, fn {key, value} ->
+      {key,
+        case key do
+        "limit" -> String.to_integer(value)
+        "skip" -> String.to_integer(value)
+        _ -> value
+        end} end)
+    #IO.inspect queries, label: "queries"
+    #case IndexRequestParams.new(conn.request.query_params) do
+    case IndexRequestParams.new(queries) do
+        {:error, _}      ->
         ErrorJson.json_by_error(conn, BadRequestError.new())
       {:ok, validated} ->
+        #IO.inspect validated
         query = convert_to_dodai_req_query(validated)
         #IO.inspect query
         req = Dodai.RetrieveDedicatedDataEntityListRequest.new(SD.default_group_id(), Helper.collection_name(), SD.root_key(), query)
@@ -27,14 +40,23 @@ defmodule StackoverflowCloneL.Controller.Question.Index do
   end
 
   defunpt convert_to_dodai_req_query(params :: v[IndexRequestParams.t]) :: Dodai.RetrieveDedicatedDataEntityListRequestQuery.t do
+    #IO.inspect params, label: "conv!!!"
     query = Map.from_struct(params)
     |> Enum.reject(fn {_, value} -> is_nil(value) end)
     |> Enum.map(fn {k, v} -> {"data.#{k}", v} end)
+    |> Enum.reject(fn {key, _} -> "data.limit" == key end)
+    |> Enum.reject(fn {key, _} -> "data.skip" == key end)
     |> Map.new()
+    #IO.inspect query, label: "query"
 
+    params = Map.from_struct(params)
+    #IO.inspect params #["limit"], label: "limit!!!"
     %Dodai.RetrieveDedicatedDataEntityListRequestQuery{
       query: query,
-      sort:  %{"_id" => 1}
+      sort:  %{"_id" => 1},
+      #limit: 3,
+      limit: params[:limit],
+      skip: params[:skip],
     }
   end
 end


### PR DESCRIPTION
## Pull Request for issue #

## 更新内容

- 実行コマンド

user_id=5cbd90cdfa26dc7de58e5542; curl -X GET "http://stackoverflow-clone-l.localhost:8080/v1/question?{user_id=${user_id}}&limit=3&skip=1" -H "accept: application/json"
